### PR TITLE
Incoming breakage: Fix `underscore_literal_suffix` in test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ mod tests {
             map.insert("sec_name".to_owned(), "you".to_owned());
             map
         };
-        let templete_str = "hello _t_name_t_ _t_sec_name_t_"_.to_owned();
+        let templete_str = "hello _t_name_t_ _t_sec_name_t_".to_owned();
 
         let ret = render(&templete_str, "_t_", &map).unwrap();
         assert_eq!(ret, "hello me you".to_owned());


### PR DESCRIPTION
This lint will soon be a hard error (https://github.com/rust-lang/rust/pull/103914). This repository is the only place where [crater](https://github.com/rust-lang/crater) found breakage.